### PR TITLE
Run deploy docs against the pipeline-specs directory specifically

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -41,7 +41,7 @@ jobs:
         run: pip install -r ./pipelines_root/requirements.txt
 
       - name: Generate pipeline docs
-        run: arcana deploy docs --flatten . docs/pipelines
+        run: arcana deploy docs --flatten pipeline-specs docs/pipelines
         working-directory: ./pipelines_root
 
       - name: Remove /docs/pipelines/ from .gitignore


### PR DESCRIPTION
Only process `yaml` files under the `pipeline-specs` directory, as other non-pipeline yaml may be accidentally processed, e.g.:

* Those in a python virtual environment from neurodocker
* The GitHub actions workflow file