### PR TITLE
Remove path filter for docs generation and re-add _index.md

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
       - main
-    paths:
-      - 'australianimagingservice/**'
-      - 'docs_scripts/**'
-      - 'docs/**'
   repository_dispatch:  # Allow access tokens which have write access to this repo to trigger this action
   workflow_dispatch:  # Allow manual triggering by a user with write access to this repo
 

--- a/docs/pipelines/_index.md
+++ b/docs/pipelines/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Pipelines"
+weight: 20
+---
+


### PR DESCRIPTION
* Remove the path filter so that docs are always regenerated
* Add back `_index.md` so that the generated documentation will be grouped under a `Pipelines` category by Docsy